### PR TITLE
remove LastActivityDate from Household object's field set

### DIFF
--- a/src/objects/Household__c.object
+++ b/src/objects/Household__c.object
@@ -114,11 +114,6 @@
             <isRequired>false</isRequired>
         </availableFields>
         <availableFields>
-            <field>LastActivityDate</field>
-            <isFieldManaged>false</isFieldManaged>
-            <isRequired>false</isRequired>
-        </availableFields>
-        <availableFields>
             <field>LastCloseDate__c</field>
             <isFieldManaged>false</isFieldManaged>
             <isRequired>false</isRequired>


### PR DESCRIPTION
# Critical Changes

# Changes
LastActivityDate has been removed from the Household__c object's Manage Household UI field set to issues with upgrading the package, if the Household__c object is no longer used.

# Issues
fixes #2187 in the Cumulus issues list