### PR TITLE
Removing references to deprecated npe01 fields

### DIFF
--- a/src/reportTypes/Households_and_Donations.reportType
+++ b/src/reportTypes/Households_and_Donations.reportType
@@ -369,16 +369,6 @@
         </columns>
         <columns>
             <checkedByDefault>false</checkedByDefault>
-            <field>npe01__Last_Donation_Date__c</field>
-            <table>Household__c.Contacts__r</table>
-        </columns>
-        <columns>
-            <checkedByDefault>false</checkedByDefault>
-            <field>npe01__Lifetime_Giving_History_Amount__c</field>
-            <table>Household__c.Contacts__r</table>
-        </columns>
-        <columns>
-            <checkedByDefault>false</checkedByDefault>
             <field>npe01__Organization_Type__c</field>
             <table>Household__c.Contacts__r</table>
         </columns>
@@ -415,11 +405,6 @@
         <columns>
             <checkedByDefault>false</checkedByDefault>
             <field>npe01__SystemAccountProcessor__c</field>
-            <table>Household__c.Contacts__r</table>
-        </columns>
-        <columns>
-            <checkedByDefault>false</checkedByDefault>
-            <field>npe01__SystemIsIndividual__c</field>
             <table>Household__c.Contacts__r</table>
         </columns>
         <columns>

--- a/version.properties
+++ b/version.properties
@@ -1,3 +1,3 @@
 required.packages=npe01,managed
-version.npe01=3.2
+version.npe01=3.3
 version.managed=Not Installed


### PR DESCRIPTION
This package still contained references to the following deprecated
fields in the Households_and_Donations report type:

Contact.npe01__Last_Donation_Date__c
Contact.npe01__Lifetime_Giving_History_Amount__c
Contact.npe01__SystemIsIndividual__c

This commit removes those references from the report type columns

This also bumps the version.properties dependency on Contacts and Organizations from 3.2 to 3.3.