### PR TITLE
Increase postal code length to avoid truncation

### DIFF
--- a/src/objects/Household__c.object
+++ b/src/objects/Household__c.object
@@ -572,7 +572,7 @@ MailingCity__c &amp; IF(LEN(MailingCity__c)  &gt; 0, &quot;, &quot;, &quot;&quot
         <externalId>false</externalId>
         <inlineHelpText>Set by the original Contact which created this Household. Can be updated in Household Edit page but does not update Contact unless &quot;Copy Household Address to Contacts&quot; button is pushed.</inlineHelpText>
         <label>Mailing Zip/Postal Code</label>
-        <length>10</length>
+        <length>20</length>
         <required>false</required>
         <trackHistory>false</trackHistory>
         <trackTrending>false</trackTrending>

--- a/src/package.xml
+++ b/src/package.xml
@@ -251,7 +251,8 @@
         <name>CustomLabel</name>
     </types>
     <types>
-        <name>CustomLabel</name>
+        <members>CustomLabels</members>
+        <name>CustomLabels</name>
     </types>
     <types>
         <members>Account</members>

--- a/src/package.xml
+++ b/src/package.xml
@@ -251,10 +251,6 @@
         <name>CustomLabel</name>
     </types>
     <types>
-        <members>CustomLabels</members>
-        <name>CustomLabels</name>
-    </types>
-    <types>
         <members>Account</members>
         <members>Campaign</members>
         <members>Contact</members>


### PR DESCRIPTION
# Critical Changes
* Household: Increase MailingPostalCode__c to 20 digits, up from 10.
  * This matches the field length of standard postal code fields [(source)](https://powerofus.force.com/s/feed/0D58000001maPqf).

# Changes
* package.xml: Remove duplicated CustomLabel metadata type.

# Issues Closed
SalesforceFoundation/Cumulus#1266