### PR TITLE
Increase Household__c MailingPostalCode length

### DIFF
--- a/src/objects/Household__c.object
+++ b/src/objects/Household__c.object
@@ -572,7 +572,7 @@ MailingCity__c &amp; IF(LEN(MailingCity__c)  &gt; 0, &quot;, &quot;, &quot;&quot
         <externalId>false</externalId>
         <inlineHelpText>Set by the original Contact which created this Household. Can be updated in Household Edit page but does not update Contact unless &quot;Copy Household Address to Contacts&quot; button is pushed.</inlineHelpText>
         <label>Mailing Zip/Postal Code</label>
-        <length>10</length>
+        <length>20</length>
         <required>false</required>
         <trackHistory>false</trackHistory>
         <trackTrending>false</trackTrending>


### PR DESCRIPTION
To avoid truncation, increase MailingPostalCode length to 20 digits, up from 10. This matches the field length of standard postal code fields.

# Critical Changes
Household__c: Increase MailingPostalCode__c length to 20 digits, up from 10.

# Changes
None

# Issues Closed
SalesforceFoundation/NPSP#1266